### PR TITLE
replaced legacy methods: componentWillMount, componentWillReceiveProps

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -108,22 +108,19 @@ class ToastContainer extends Component {
         };
     }
 
-    componentWillMount() {
+    componentDidMount = () => {
         Dimensions.addEventListener('change', this._windowChanged);
         if (this.props.keyboardAvoiding) {
             Keyboard.addListener('keyboardDidChangeFrame', this._keyboardDidChangeFrame);
         }
-    }
-
-    componentDidMount = () => {
         if (this.state.visible) {
             this._showTimeout = setTimeout(() => this._show(), this.props.delay);
         }
     };
 
-    componentWillReceiveProps = nextProps => {
-        if (nextProps.visible !== this.props.visible) {
-            if (nextProps.visible) {
+    componentDidUpdate = prevProps => {
+        if (this.props.visible !== prevProps.visible) {
+            if (this.props.visible) {
                 clearTimeout(this._showTimeout);
                 clearTimeout(this._hideTimeout);
                 this._showTimeout = setTimeout(() => this._show(), this.props.delay);
@@ -132,7 +129,7 @@ class ToastContainer extends Component {
             }
 
             this.setState({
-                visible: nextProps.visible
+                visible: this.props.visible
             });
         }
     };


### PR DESCRIPTION
Fixed the following warnings:

- componentWillMount has been renamed, and is not recommended for use.
  See https://fb.me/react-async-component-lifecycle-hooks for details.

- componentWillReceiveProps has been renamed, and is not recommended for use.
  See https://fb.me/react-async-component-lifecycle-hooks for details.